### PR TITLE
Move to strscpy

### DIFF
--- a/t2bce_audio/audio.c
+++ b/t2bce_audio/audio.c
@@ -441,8 +441,7 @@ static void t2audio_init_dev(struct t2audio_device *a, t2audio_device_id_t dev_i
     INIT_LIST_HEAD(&sdev->list);
     sdev->dev_id = dev_id;
     sdev->buf_id = T2AUDIO_BUFFER_ID_NONE;
-    strncpy(sdev->uid, uid, uid_len);
-    sdev->uid[uid_len + 1] = '\0';
+    strscpy(sdev->uid, uid);
 
     if (t2audio_cmd_get_primitive_property(a, dev_id, dev_id,
             T2AUDIO_PROP(T2AUDIO_PROP_SCOPE_INPUT, T2AUDIO_PROP_LATENCY, 0), NULL, 0, &sdev->in_latency, sizeof(u32)))


### PR DESCRIPTION
strncpy has been depreciated for a long time, and finally removed from kernel 7.2