### PR TITLE
t2bce_audio: NUL-terminate device UID string before calling strscpy

### DIFF
--- a/t2bce_audio/audio.c
+++ b/t2bce_audio/audio.c
@@ -435,6 +435,7 @@ static void t2audio_init_dev(struct t2audio_device *a, t2audio_device_id_t dev_i
         dev_err(a->dev, "Failed to get device uid for device %llx\n", dev_id);
         goto fail;
     }
+    uid[uid_len] = '\0';
     pr_debug("t2bce_audio: Remote device %llx %.*s\n", dev_id, (int) uid_len, uid);
 
     sdev->a = a;


### PR DESCRIPTION
The bridgeOS BCE property query for T2AUDIO_PROP_UID returns a raw string bytes payload without a trailing NUL byte.

When strscpy(sdev->uid, uid) is called, it scans the source buffer past uid_len looking for a NUL byte, copying trailing message payload garbage (e.g., "Speaker@mcpl\x04") into sdev->uid. This breaks subdevice lookup by UID in t2audio_init_bs(), causing stream initialization to be skipped and leaving stream->alsa_hw_desc as NULL.

Explicitly NUL-terminate the uid buffer at uid_len before passing it to strscpy() to ensure clean, proper string copying according to Linux 7.2 kernel string standards.