### PR TITLE
t2bce_audio: fix internal mic capture

### DIFF
--- a/t2bce_audio/audio.c
+++ b/t2bce_audio/audio.c
@@ -9,6 +9,7 @@
 #include <sound/jack.h>
 #include "audio.h"
 #include "pcm.h"
+#include "clock.h"
 #include <linux/version.h>
 
 static int t2audio_alsa_index = SNDRV_DEFAULT_IDX1;
@@ -219,14 +220,14 @@ static int t2audio_quiesce(struct t2audio_device *t2audio, bool suspend_pcm)
             if (!smp_load_acquire(&sdev->out_streams[i].started))
                 continue;
             stopped_io = true;
-            smp_store_release(&sdev->out_streams[i].started, 0);
+            t2audio_pcm_stop_period_timer(&sdev->out_streams[i]);
         }
 
         for (i = 0; i < sdev->in_stream_cnt; i++) {
             if (!smp_load_acquire(&sdev->in_streams[i].started))
                 continue;
             stopped_io = true;
-            smp_store_release(&sdev->in_streams[i].started, 0);
+            t2audio_pcm_stop_period_timer(&sdev->in_streams[i]);
         }
 
         if (stopped_io)
@@ -350,7 +351,7 @@ static void t2audio_resume_complete(void *userdata)
 
 static void t2audio_reset_stream(struct t2audio_stream *stream)
 {
-    smp_store_release(&stream->started, 0);
+    t2audio_pcm_stop_period_timer(stream);
     stream->waiting_for_first_ts = true;
     stream->remote_timestamp = 0;
     stream->timestamp_accept_after = 0;
@@ -465,6 +466,7 @@ static void t2audio_init_dev(struct t2audio_device *a, t2audio_device_id_t dev_i
         sdev->in_streams[i].id = stream_list[i];
         sdev->in_streams[i].buffer_cnt = 0;
         t2audio_init_stream_info(sdev, &sdev->in_streams[i]);
+        t2audio_pcm_init_stream(&sdev->in_streams[i]);
         sdev->in_streams[i].latency += sdev->in_latency;
     }
 
@@ -482,6 +484,7 @@ static void t2audio_init_dev(struct t2audio_device *a, t2audio_device_id_t dev_i
         sdev->out_streams[i].id = stream_list[i];
         sdev->out_streams[i].buffer_cnt = 0;
         t2audio_init_stream_info(sdev, &sdev->out_streams[i]);
+        t2audio_pcm_init_stream(&sdev->out_streams[i]);
         sdev->out_streams[i].latency += sdev->out_latency;
     }
 
@@ -523,12 +526,14 @@ static void t2audio_free_dev(struct t2audio_subdevice *sdev)
 {
     size_t i;
     for (i = 0; i < sdev->in_stream_cnt; i++) {
+        t2audio_pcm_stop_period_timer(&sdev->in_streams[i]);
         if (sdev->in_streams[i].alsa_hw_desc)
             kfree(sdev->in_streams[i].alsa_hw_desc);
         if (sdev->in_streams[i].buffers)
             kfree(sdev->in_streams[i].buffers);
     }
     for (i = 0; i < sdev->out_stream_cnt; i++) {
+        t2audio_pcm_stop_period_timer(&sdev->out_streams[i]);
         if (sdev->out_streams[i].alsa_hw_desc)
             kfree(sdev->out_streams[i].alsa_hw_desc);
         if (sdev->out_streams[i].buffers)
@@ -698,6 +703,33 @@ static void t2audio_init_bs_stream_host(struct t2audio_device *a, struct t2audio
     if (t2audio_create_hw_info(&strm->desc, strm->alsa_hw_desc, strm->buffers[0].size)) {
         kfree(strm->alsa_hw_desc);
         strm->alsa_hw_desc = NULL;
+    } else {
+        /*
+         * t2audio_create_hw_info() sizes each ALSA period as exactly one
+         * Apple audio packet (often a single frame). Combined with
+         * SNDRV_PCM_INFO_NO_PERIOD_WAKEUP and a purely time-interpolated
+         * pointer, this forces user space to service the entire buffer
+         * within a single frame's time, hitting a hard overrun before it
+         * can ever complete a read. Re-tune the period size to roughly
+         * 10ms so normal blocking reads have realistic headroom. This is
+         * host-side bookkeeping only and does not affect the wire format.
+         */
+        struct snd_pcm_hardware *hw = strm->alsa_hw_desc;
+        u64 rate = t2audio_double_to_u64(strm->desc.sample_rate_double);
+        u64 total_frames = strm->buffers[0].size / strm->desc.bytes_per_packet;
+        u64 target_frames = rate ? (rate / 100) : total_frames; /* ~10ms */
+        u64 periods = target_frames ? (total_frames / target_frames) : 1;
+
+        if (periods < 1)
+            periods = 1;
+
+        hw->period_bytes_min = (unsigned) ((total_frames / periods) * strm->desc.bytes_per_packet);
+        hw->period_bytes_max = hw->period_bytes_min;
+        hw->periods_min = (unsigned) periods;
+        hw->periods_max = (unsigned) periods;
+
+        pr_debug("t2bce_audio: retuned capture periods: periods=%u period_bytes=%u\n",
+                (unsigned) hw->periods_min, (unsigned) hw->period_bytes_min);
     }
 }
 
@@ -815,7 +847,7 @@ void t2audio_handle_cmd_timestamp(struct t2audio_device *a, struct t2audio_msg *
             a->clock_samples++;
     }
     clock_offset_ns = a->clock_offset_ns;
-    clock_ready = a->clock_samples >= 2;
+    clock_ready = t2audio_clock_ready(a->clock_samples);
     spin_unlock_irqrestore(&a->clock_lock, flags);
     pr_debug("t2bce_audio: timestamp dev=%llx t2=%llx host=%lld seed=%llx sample_offset=%lld clock_offset=%lld\n",
             devid, timestamp, ktime_to_ns(time_os), update_seed,

--- a/t2bce_audio/audio.h
+++ b/t2bce_audio/audio.h
@@ -3,6 +3,7 @@
 
 #include <linux/types.h>
 #include <linux/workqueue.h>
+#include <linux/hrtimer.h>
 #include <sound/pcm.h>
 #include "t2bce_core_transport.h"
 #include "protocol_bce.h"
@@ -85,6 +86,10 @@ struct t2audio_stream {
     bool clock_offset_valid;
     snd_pcm_sframes_t frame_min;
     int started;
+    struct hrtimer period_timer;
+    struct work_struct period_work;
+    struct snd_pcm_substream *substream;
+    ktime_t period_time;
 };
 struct t2audio_subdevice {
     struct t2audio_device *a;

--- a/t2bce_audio/clock.h
+++ b/t2bce_audio/clock.h
@@ -1,0 +1,17 @@
+#ifndef T2AUDIO_CLOCK_H
+#define T2AUDIO_CLOCK_H
+
+static inline bool t2audio_clock_ready(unsigned int samples)
+{
+    return samples >= 1;
+}
+static inline unsigned long long t2audio_period_ns(unsigned int period_size,
+        unsigned int rate)
+{
+    if (!rate)
+        return 0;
+
+    return 1000000000ULL * period_size / rate;
+}
+
+#endif

--- a/t2bce_audio/pcm.c
+++ b/t2bce_audio/pcm.c
@@ -1,8 +1,10 @@
 #include "pcm.h"
 #include "audio.h"
+#include "clock.h"
 #include <linux/dma-mapping.h>
 #include <linux/io.h>
 #include <linux/ktime.h>
+#include <linux/pci.h>
 
 static u64 t2audio_get_alsa_fmtbit(struct t2audio_apple_description *desc)
 {
@@ -76,7 +78,6 @@ int t2audio_create_hw_info(struct t2audio_apple_description *desc, struct snd_pc
     alsa_hw->info = (SNDRV_PCM_INFO_MMAP |
                      SNDRV_PCM_INFO_BLOCK_TRANSFER |
                      SNDRV_PCM_INFO_MMAP_VALID |
-                     SNDRV_PCM_INFO_NO_PERIOD_WAKEUP |
                      SNDRV_PCM_INFO_DOUBLE);
     if (desc->format_flags & T2AUDIO_FORMAT_FLAG_NON_MIXABLE)
         pr_warn("t2bce_audio: unsupported hw flag: NON_MIXABLE\n");
@@ -117,6 +118,70 @@ static struct t2audio_dma_buf *t2audio_pcm_dma_buf(struct t2audio_stream *stream
         return NULL;
 
     return &stream->buffers[0];
+}
+
+static void t2audio_pcm_period_work(struct work_struct *work)
+{
+    struct t2audio_stream *stream = container_of(work, struct t2audio_stream, period_work);
+    struct snd_pcm_substream *substream = READ_ONCE(stream->substream);
+
+    if (smp_load_acquire(&stream->started) && substream)
+        snd_pcm_period_elapsed(substream);
+}
+
+static enum hrtimer_restart t2audio_pcm_period_timer(struct hrtimer *timer)
+{
+    struct t2audio_stream *stream = container_of(timer, struct t2audio_stream, period_timer);
+
+    if (!smp_load_acquire(&stream->started))
+        return HRTIMER_NORESTART;
+
+    schedule_work(&stream->period_work);
+    hrtimer_forward_now(timer, stream->period_time);
+    return HRTIMER_RESTART;
+}
+
+void t2audio_pcm_init_stream(struct t2audio_stream *stream)
+{
+    hrtimer_setup(&stream->period_timer, t2audio_pcm_period_timer,
+            CLOCK_MONOTONIC, HRTIMER_MODE_REL_SOFT);
+    INIT_WORK(&stream->period_work, t2audio_pcm_period_work);
+}
+
+static void t2audio_pcm_start_period_timer(struct t2audio_stream *stream,
+        struct snd_pcm_substream *substream)
+{
+    unsigned long long period_ns = t2audio_period_ns(substream->runtime->period_size,
+            substream->runtime->rate);
+
+    if (!period_ns)
+        return;
+
+    WRITE_ONCE(stream->substream, substream);
+    stream->period_time = ns_to_ktime(period_ns);
+    hrtimer_start(&stream->period_timer, stream->period_time, HRTIMER_MODE_REL_SOFT);
+}
+
+/*
+ * Safe while the PCM stream lock is held (trigger/prepare): never waits on
+ * the timer callback or the notification work. A work item that already
+ * started may still call snd_pcm_period_elapsed() once; that is harmless on
+ * a stopped stream. Waiting here instead deadlocks, because the work item
+ * blocks on the PCM stream lock our caller holds.
+ */
+void t2audio_pcm_halt_period_timer(struct t2audio_stream *stream)
+{
+    smp_store_release(&stream->started, 0);
+    hrtimer_try_to_cancel(&stream->period_timer);
+}
+
+/* Full synchronous stop; must not be called with the PCM stream lock held. */
+void t2audio_pcm_stop_period_timer(struct t2audio_stream *stream)
+{
+    smp_store_release(&stream->started, 0);
+    hrtimer_cancel(&stream->period_timer);
+    cancel_work_sync(&stream->period_work);
+    WRITE_ONCE(stream->substream, NULL);
 }
 
 static void t2audio_dma_memset(struct t2audio_dma_buf *buf, size_t offset, int value, size_t size)
@@ -211,6 +276,9 @@ static int t2audio_pcm_open(struct snd_pcm_substream *substream)
 static int t2audio_pcm_close(struct snd_pcm_substream *substream)
 {
     struct t2audio_subdevice *sdev = snd_pcm_substream_chip(substream);
+    struct t2audio_stream *stream = t2audio_pcm_stream(substream);
+
+    t2audio_pcm_stop_period_timer(stream);
 
     pr_debug("t2bce_audio: pcm close dev=%s direction=%s substream=%u\n",
             sdev->uid,
@@ -222,6 +290,7 @@ static int t2audio_pcm_close(struct snd_pcm_substream *substream)
 static int t2audio_pcm_prepare(struct snd_pcm_substream *substream)
 {
     struct t2audio_stream *stream = t2audio_pcm_stream(substream);
+    t2audio_pcm_halt_period_timer(stream);
 
     stream->waiting_for_first_ts = true;
     stream->remote_timestamp = 0;
@@ -347,7 +416,7 @@ static int t2audio_pcm_trigger(struct snd_pcm_substream *substream, int cmd)
             break;
         case SNDRV_PCM_TRIGGER_STOP:
             pr_debug("t2bce_audio: TRIGGER STOP %s\n", sdev->uid);
-            smp_store_release(&stream->started, 0);
+            t2audio_pcm_halt_period_timer(stream);
             err = t2audio_cmd_stop_io(sdev->a, sdev->dev_id);
             stream->remote_timestamp = 0;
             stream->waiting_for_first_ts = true;
@@ -412,7 +481,7 @@ static int t2audio_pcm_mmap(struct snd_pcm_substream *substream, struct vm_area_
         case T2AUDIO_DMA_BUF_IOMEM:
             return snd_pcm_lib_mmap_iomem(substream, area);
         case T2AUDIO_DMA_BUF_COHERENT:
-            return dma_mmap_coherent(sdev->a->dev, area, buf->ptr, buf->dma_addr, buf->size);
+            return dma_mmap_coherent(&sdev->a->pci->dev, area, buf->ptr, buf->dma_addr, buf->size);
         default:
             return -EINVAL;
     }
@@ -497,6 +566,7 @@ static void t2audio_handle_stream_timestamp(struct snd_pcm_substream *substream,
     if (stream->waiting_for_first_ts) {
         stream->waiting_for_first_ts = false;
         snd_pcm_stream_unlock_irqrestore(substream, flags);
+        t2audio_pcm_start_period_timer(stream, substream);
         return;
     }
     snd_pcm_stream_unlock_irqrestore(substream, flags);

--- a/t2bce_audio/pcm.h
+++ b/t2bce_audio/pcm.h
@@ -5,11 +5,15 @@
 #include <linux/ktime.h>
 
 struct t2audio_subdevice;
+struct t2audio_stream;
 struct t2audio_apple_description;
 struct snd_pcm_hardware;
 
 int t2audio_create_hw_info(struct t2audio_apple_description *desc, struct snd_pcm_hardware *alsa_hw, size_t buf_size);
 int t2audio_create_pcm(struct t2audio_subdevice *sdev);
+void t2audio_pcm_init_stream(struct t2audio_stream *stream);
+void t2audio_pcm_halt_period_timer(struct t2audio_stream *stream);
+void t2audio_pcm_stop_period_timer(struct t2audio_stream *stream);
 
 void t2audio_handle_timestamp(struct t2audio_subdevice *sdev, u64 dev_timestamp,
         u64 update_seed, s64 clock_offset_ns, bool clock_ready);

--- a/tests/test_clock_readiness.c
+++ b/tests/test_clock_readiness.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdbool.h>
+
+#include "../t2bce_audio/clock.h"
+
+int main(void)
+{
+    assert(t2audio_clock_ready(0) == false);
+    assert(t2audio_clock_ready(1) == true);
+    assert(t2audio_clock_ready(2) == true);
+
+    return 0;
+}

--- a/tests/test_period_timer.c
+++ b/tests/test_period_timer.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdbool.h>
+
+#include "../t2bce_audio/clock.h"
+
+int main(void)
+{
+    assert(t2audio_period_ns(489, 48000) == 10187500ULL);
+    assert(t2audio_period_ns(0, 48000) == 0);
+    assert(t2audio_period_ns(489, 0) == 0);
+
+    return 0;
+}


### PR DESCRIPTION
Capture on the internal Digital Mic failed with EIO roughly 330ms after start and produced empty recordings. Three independent bugs:

- Host/remote clock correlation required two timestamp samples before marking the clock ready, but bridgeOS sends only one timestamp per capture session, so the stream pointer never left position zero. Accept the first valid post-start timestamp for calibration.

- The capture stream advertised SNDRV_PCM_INFO_NO_PERIOD_WAKEUP with one-frame periods, so blocking readers were never woken and the ring overran after one buffer length (~346ms). Size host capture periods to roughly 10ms and drive period notifications from a soft hrtimer started once the first timestamp is accepted. Notifications run from a work item because snd_pcm_period_elapsed() can trigger a stop that sends a synchronous BCE command and may sleep.

- t2audio_pcm_mmap() mapped coherent capture buffers with the class device instead of the PCI device that allocated them, so with an active IOMMU userspace mapped the wrong pages and mmap-based readers such as PipeWire captured digital silence while read()-based capture worked. Map with the allocating PCI device.

Host-side regression tests for clock readiness and period-duration calculation live in tests/ and build with plain gcc.

Tested on MacBookPro16,4 (kernel 7.1.8-1-t2-resolute): arecord from the Digital Mic PCM records real audio for arbitrary durations, and PipeWire mmap capture carries speech at normal levels.